### PR TITLE
Fixes #3: OnNetworkConnection now uses a `string` for the `connectionID`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.7: Changing `connectionID`
+
+This release changes the `connectionID` parameter to a string. This better conveys that it is a printable string and can be safely used in filenames, etc.
+
 ## 0.9.6: OnHandshakeSuccess takes username
 
 With `0.9.6` we are introducing the `user` parameter to the `OnHandshakeSuccess()` method. This is done in preparation to supporting SSH connections without authentication.

--- a/README.md
+++ b/README.md
@@ -63,4 +63,8 @@ The handler interface consists of multiple parts:
 - The `SSHConnectionHandler` is responsible for handling an individual SSH connection. Most importantly, it is responsible for providing a `SessionChannelHandler` when a new session channel is requested by the client.
 - The `SessionChannelHandler` is responsible for an individual session channel (single program execution). It provides several hooks for setting up and running the program. Once the program execution is complete the channel is closed. You must, however, keep handling requests (e.g. window size change) during program execution.
 
-A sample implementation can be found in the [test code](integration_test.go) at the bottom of the file.
+A sample implementation can be found in the [test code](server_test.go) at the bottom of the file.
+
+## About the `connectionID`
+
+The `connectionID` parameter in the `OnNetworkConnection()` is a hexadecimal string uniquely identifying a connection. This ID can be used to track connection-related information across multiple subsystems (e.g. logs, audit logs, authentication and configuration requests, etc.)

--- a/handler.go
+++ b/handler.go
@@ -25,7 +25,7 @@ type Handler interface {
 	//
 	// The ip parameter provides the IP address of the connecting user. The connectionID parameter provides an opaque
 	// binary identifier for the connection that can be used to track the connection across multiple subsystems.
-	OnNetworkConnection(client net.TCPAddr, connectionID []byte) (NetworkConnectionHandler, error)
+	OnNetworkConnection(client net.TCPAddr, connectionID string) (NetworkConnectionHandler, error)
 }
 
 // AuthResponse indicates the various response states for the authentication process.

--- a/server_impl.go
+++ b/server_impl.go
@@ -1,6 +1,7 @@
 package sshserver
 
 import (
+	"encoding/hex"
 	"fmt"
 	"net"
 	"sync"
@@ -163,13 +164,13 @@ func (s *server) createConfiguration(handlerNetworkConnection NetworkConnectionH
 
 func (s *server) handleConnection(conn net.Conn) {
 	addr := conn.RemoteAddr().(*net.TCPAddr)
-	connectionID, err := uuid.New().MarshalBinary()
+	connectionIDBinary, err := uuid.New().MarshalBinary()
 	if err != nil {
 		s.logger.Warningf("failed to generate unique connection ID for %s (%w)", addr.IP.String(), err)
 		_ = conn.Close()
 		return
 	}
-	handlerNetworkConnection, err := s.handler.OnNetworkConnection(*addr, connectionID)
+	handlerNetworkConnection, err := s.handler.OnNetworkConnection(*addr, hex.EncodeToString(connectionIDBinary))
 	if err != nil {
 		s.logger.Infoe(err)
 		_ = conn.Close()

--- a/server_test.go
+++ b/server_test.go
@@ -271,7 +271,7 @@ func (r *rejectHandler) OnReady() error {
 func (r *rejectHandler) OnShutdown(_ context.Context) {
 }
 
-func (r *rejectHandler) OnNetworkConnection(_ net.TCPAddr, _ []byte) (sshserver.NetworkConnectionHandler, error) {
+func (r *rejectHandler) OnNetworkConnection(_ net.TCPAddr, _ string) (sshserver.NetworkConnectionHandler, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
@@ -313,7 +313,7 @@ func (f *fullHandler) OnShutdown(shutdownContext context.Context) {
 	f.shutdownDone <- struct{}{}
 }
 
-func (f *fullHandler) OnNetworkConnection(_ net.TCPAddr, _ []byte) (sshserver.NetworkConnectionHandler, error) {
+func (f *fullHandler) OnNetworkConnection(_ net.TCPAddr, _ string) (sshserver.NetworkConnectionHandler, error) {
 	return &fullNetworkConnectionHandler{
 		handler: f,
 	}, nil


### PR DESCRIPTION
OnNetworkConnection now uses a `string` for the `connectionID` instead of a `[]byte`. The connection ID is guaranteed to contain only hexadecimal characters.