### PR TITLE
Changing the pubKey authenticator to use the authorized key format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.8: Changing the pubKey authenticator to use the authorized key format
+
+In this release we are changing the `OnAuthPubKey` method of the `NetworkConnectionHandler` interface to receive a `string` instead of a `[]byte` for the pubkey. The SSH server implementation now passes the SSH key in the [OpenSSH authorized key format](https://en.wikibooks.org/wiki/OpenSSH/Client_Configuration_Files#~/.ssh/authorized_keys) to make it easier for implementers to match the key.
+
 ## 0.9.7: Changing `connectionID`
 
 This release changes the `connectionID` parameter to a string. This better conveys that it is a printable string and can be safely used in filenames, etc.

--- a/handler.go
+++ b/handler.go
@@ -50,8 +50,9 @@ type NetworkConnectionHandler interface {
 	OnAuthPassword(username string, password []byte) (response AuthResponse, reason error)
 
 	// OnAuthPassword is called when a user attempts a pubkey authentication. The implementation must always supply
-	//                AuthResponse and may supply error as a reason description.
-	OnAuthPubKey(username string, pubKey []byte) (response AuthResponse, reason error)
+	//                AuthResponse and may supply error as a reason description. The pubKey parameter is an SSH key in
+	//               the form of "ssh-rsa KEY HERE".
+	OnAuthPubKey(username string, pubKey string) (response AuthResponse, reason error)
 
 	// OnHandshakeFailed is called when the SSH handshake failed. This method is also called after an authentication
 	//                   failure. After this method is the connection will be closed and the OnDisconnect method will be

--- a/server_impl.go
+++ b/server_impl.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net"
+	"strings"
 	"sync"
 
 	"github.com/containerssh/log"
@@ -128,7 +129,8 @@ func (s *server) createPubKeyAuthenticator(
 	handlerNetworkConnection NetworkConnectionHandler,
 ) func(conn ssh.ConnMetadata, pubKey ssh.PublicKey) (*ssh.Permissions, error) {
 	return func(conn ssh.ConnMetadata, pubKey ssh.PublicKey) (*ssh.Permissions, error) {
-		authResponse, err := handlerNetworkConnection.OnAuthPubKey(conn.User(), pubKey.Marshal())
+		authorizedKey := strings.TrimSpace(string(ssh.MarshalAuthorizedKey(pubKey)))
+		authResponse, err := handlerNetworkConnection.OnAuthPubKey(conn.User(), authorizedKey)
 		switch authResponse {
 		case AuthResponseSuccess:
 			return &ssh.Permissions{}, nil


### PR DESCRIPTION
In this release we are changing the `OnAuthPubKey` method of the `NetworkConnectionHandler` interface to receive a `string` instead of a `[]byte` for the pubkey. The SSH server implementation now passes the SSH key in the [OpenSSH authorized key format](https://en.wikibooks.org/wiki/OpenSSH/Client_Configuration_Files#~/.ssh/authorized_keys) to make it easier for implementers to match the key.