### PR TITLE
Bugfixing request decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.10: Bugfixing request decoding
+
+In the previous versions of this library the fields in the structures related to SSH requests (e.g. env) were not exported. This caused the ssh unmarshal to fail, but this was not tested previously. We have now changed the fields to be exported and sending requests has now been added to the test scope. More test cases are desirable in future.
+
 ## 0.9.9: Configuration structure now accepts strings instead of ssh.Signer
           
 This change replaces the host keys configuration parameter ([]ssh.Signer) with a slice of strings. This is done to preserve the file-based host keys when a configuration structure needs to be saved later.

--- a/handler.go
+++ b/handler.go
@@ -153,12 +153,12 @@ type SessionChannelHandler interface {
 	//              return an error to reject the request.
 	//
 	// requestID is an incrementing number uniquely identifying this request within the channel.
-	// term is the terminal name. This is usually set in the TERM environment variable.
-	// columns is the number of columns in the terminal.
-	// rows is the number of rows in the terminal.
-	// width is the width of the terminal in pixels.
-	// height is the height of a terminal in pixels.
-	// modelist are the encoded terminal modes the client desires. See RFC4254 section 8 and RFC8160 for details.
+	// Term is the terminal Name. This is usually set in the TERM environment variable.
+	// Columns is the number of Columns in the terminal.
+	// Rows is the number of Rows in the terminal.
+	// Width is the Width of the terminal in pixels.
+	// Height is the Height of a terminal in pixels.
+	// ModeList are the encoded terminal modes the client desires. See RFC4254 section 8 and RFC8160 for details.
 	OnPtyRequest(
 		requestID uint64,
 		term string,
@@ -177,7 +177,7 @@ type SessionChannelHandler interface {
 	//               to reject the request.
 	//
 	// requestID is an incrementing number uniquely identifying this request within the channel.
-	// program is the name of the program to be executed.
+	// program is the Name of the program to be executed.
 	// stdin is a reader for the shell or program to read the stdin.
 	// stdout is a writer for the shell or program standard output.
 	// stderr is a writer for the shell or program standard error.
@@ -208,7 +208,7 @@ type SessionChannelHandler interface {
 		onExit func(exitStatus ExitStatus),
 	) error
 
-	// OnSubsystem is called when the client calls a well-known subsystem (e.g. sftp). The implementation can return an
+	// OnSubsystem is called when the client calls a well-known Subsystem (e.g. sftp). The implementation can return an
 	//             error to reject the request. The implementation should send the IO handling into background. It
 	//             should also respect the shutdown context on the Handler.
 	//
@@ -230,7 +230,7 @@ type SessionChannelHandler interface {
 
 	//region Requests during program execution
 
-	// OnSignal is called when the client requests a signal to be sent to the running process. The implementation can
+	// OnSignal is called when the client requests a Signal to be sent to the running process. The implementation can
 	//          return an error to reject the request.
 	OnSignal(
 		requestID uint64,
@@ -241,10 +241,10 @@ type SessionChannelHandler interface {
 	//          after a program is started. The implementation can return an error to reject the request.
 	//
 	// requestID is an incrementing number uniquely identifying this request within the channel.
-	// columns is the number of columns in the terminal.
-	// rows is the number of rows in the terminal.
-	// width is the width of the terminal in pixels.
-	// height is the height of a terminal in pixels.
+	// Columns is the number of Columns in the terminal.
+	// Rows is the number of Rows in the terminal.
+	// Width is the Width of the terminal in pixels.
+	// Height is the Height of a terminal in pixels.
 	OnWindow(
 		requestID uint64,
 		columns uint32,

--- a/server_impl.go
+++ b/server_impl.go
@@ -239,39 +239,39 @@ func (s *server) handleChannels(channels <-chan ssh.NewChannel, connection SSHCo
 }
 
 type envRequestPayload struct {
-	name  string
-	value string
+	Name  string
+	Value string
 }
 
 type execRequestPayload struct {
-	exec string
+	Exec string
 }
 
 type ptyRequestPayload struct {
-	term     string
-	columns  uint32
-	rows     uint32
-	width    uint32
-	height   uint32
-	modelist []byte
+	Term     string
+	Columns  uint32
+	Rows     uint32
+	Width    uint32
+	Height   uint32
+	ModeList []byte
 }
 
 type shellRequestPayload struct {
 }
 
 type signalRequestPayload struct {
-	signal string
+	Signal string
 }
 
 type subsystemRequestPayload struct {
-	subsystem string
+	Subsystem string
 }
 
 type windowRequestPayload struct {
-	columns uint32
-	rows    uint32
-	width   uint32
-	height  uint32
+	Columns uint32
+	Rows    uint32
+	Width   uint32
+	Height  uint32
 }
 
 type exitStatusPayload struct {
@@ -284,10 +284,10 @@ const (
 	requestTypeEnv       requestType = "env"
 	requestTypePty       requestType = "pty"
 	requestTypeShell     requestType = "shell"
-	requestTypeExec      requestType = "exec"
-	requestTypeSubsystem requestType = "subsystem"
+	requestTypeExec      requestType = "Exec"
+	requestTypeSubsystem requestType = "Subsystem"
 	requestTypeWindow    requestType = "window-change"
-	requestTypeSignal    requestType = "signal"
+	requestTypeSignal    requestType = "Signal"
 )
 
 func (s *server) handleSessionChannel(channelID uint64, newChannel ssh.NewChannel, connection SSHConnectionHandler) {
@@ -447,20 +447,20 @@ func (s *server) handleDecodedChannelRequest(
 func (s *server) onEnvRequest(requestID uint64, sessionChannel SessionChannelHandler, payload interface{}) error {
 	return sessionChannel.OnEnvRequest(
 		requestID,
-		payload.(envRequestPayload).name,
-		payload.(envRequestPayload).value,
+		payload.(envRequestPayload).Name,
+		payload.(envRequestPayload).Value,
 	)
 }
 
 func (s *server) onPtyRequest(requestID uint64, sessionChannel SessionChannelHandler, payload interface{}) error {
 	return sessionChannel.OnPtyRequest(
 		requestID,
-		payload.(ptyRequestPayload).term,
-		payload.(ptyRequestPayload).columns,
-		payload.(ptyRequestPayload).rows,
-		payload.(ptyRequestPayload).width,
-		payload.(ptyRequestPayload).height,
-		payload.(ptyRequestPayload).modelist,
+		payload.(ptyRequestPayload).Term,
+		payload.(ptyRequestPayload).Columns,
+		payload.(ptyRequestPayload).Rows,
+		payload.(ptyRequestPayload).Width,
+		payload.(ptyRequestPayload).Height,
+		payload.(ptyRequestPayload).ModeList,
 	)
 }
 
@@ -477,7 +477,7 @@ func (s *server) onShell(requestID uint64, sessionChannel SessionChannelHandler,
 func (s *server) onExec(requestID uint64, sessionChannel SessionChannelHandler, payload interface{}, channel ssh.Channel, onExit func(exitCode ExitStatus)) error {
 	return sessionChannel.OnExecRequest(
 		requestID,
-		payload.(execRequestPayload).exec,
+		payload.(execRequestPayload).Exec,
 		channel,
 		channel,
 		channel.Stderr(),
@@ -488,14 +488,14 @@ func (s *server) onExec(requestID uint64, sessionChannel SessionChannelHandler, 
 func (s *server) onSignal(requestID uint64, sessionChannel SessionChannelHandler, payload interface{}) error {
 	return sessionChannel.OnSignal(
 		requestID,
-		payload.(signalRequestPayload).signal,
+		payload.(signalRequestPayload).Signal,
 	)
 }
 
 func (s *server) onSubsystem(requestID uint64, sessionChannel SessionChannelHandler, payload interface{}, channel ssh.Channel, onExit func(exitCode ExitStatus)) error {
 	return sessionChannel.OnSubsystem(
 		requestID,
-		payload.(subsystemRequestPayload).subsystem,
+		payload.(subsystemRequestPayload).Subsystem,
 		channel,
 		channel,
 		channel.Stderr(),
@@ -506,10 +506,10 @@ func (s *server) onSubsystem(requestID uint64, sessionChannel SessionChannelHand
 func (s *server) onChannel(requestID uint64, sessionChannel SessionChannelHandler, payload interface{}) error {
 	return sessionChannel.OnWindow(
 		requestID,
-		payload.(windowRequestPayload).columns,
-		payload.(windowRequestPayload).rows,
-		payload.(windowRequestPayload).width,
-		payload.(windowRequestPayload).height,
+		payload.(windowRequestPayload).Columns,
+		payload.(windowRequestPayload).Rows,
+		payload.(windowRequestPayload).Width,
+		payload.(windowRequestPayload).Height,
 	)
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -286,6 +286,10 @@ func shellRequestReply(
 		return nil, -1, err
 	}
 
+	if err := session.Setenv("TERM", "xterm"); err != nil {
+		return nil, -1, err
+	}
+
 	if err := session.Shell(); err != nil {
 		return nil, -1, fmt.Errorf("failed to request shell (%w)", err)
 	}
@@ -572,7 +576,7 @@ func (f *fullSessionChannelHandler) OnEnvRequest(_ uint64, name string, value st
 func (f *fullSessionChannelHandler) OnExecRequest(
 	_ uint64, _ string, _ io.Reader, _ io.Writer, _ io.Writer, _ func(exitStatus sshserver.ExitStatus),
 ) error {
-	return fmt.Errorf("this server does not support exec")
+	return fmt.Errorf("this server does not support Exec")
 }
 
 func (f *fullSessionChannelHandler) OnPtyRequest(
@@ -611,7 +615,7 @@ func (f *fullSessionChannelHandler) OnSignal(_ uint64, _ string) error {
 func (f *fullSessionChannelHandler) OnSubsystem(
 	_ uint64, _ string, _ io.Reader, _ io.Writer, _ io.Writer, _ func(exitStatus sshserver.ExitStatus),
 ) error {
-	return fmt.Errorf("subsystem not supported")
+	return fmt.Errorf("Subsystem not supported")
 }
 
 func (f *fullSessionChannelHandler) OnWindow(_ uint64, _ uint32, _ uint32, _ uint32, _ uint32) error {


### PR DESCRIPTION
In the previous versions of this library the fields in the structures related to SSH requests (e.g. env) were not exported. This caused the ssh unmarshal to fail, but this was not tested previously. We have now changed the fields to be exported and sending requests has now been added to the test scope. More test cases are desirable in future.