### PR TITLE
Moving the OnHandshakeSuccessful handler to authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.9.12: Moving the OnHandshakeSuccessful handler to authentication
+
+This change moves the call to OnHandshakeSuccessful before sending the "auth success" message to the client.
+
+This is required because we noticed that clients would immediately start sending requests (e.g. PTY requests) to the server while the container backend is still initializing. If the container initialization takes too long the PTY request would be considered failed by the client resulting in the error message "PTY allocation request failed on channel 0". By delaying sending the authentication response to the client we can make sure the container backend has ample time to start up the container.
+
 ## 0.9.11: Exec request bug
 
 This release fixes a bug where Exec requests would be rejected due to faulty refactoring in the previous release.

--- a/HACKS.md
+++ b/HACKS.md
@@ -1,0 +1,13 @@
+# Hacks
+
+This file is intended to keep track of the hacks in the SSH server library.
+
+## OnHandshakeSuccess handler
+
+We call the `OnHandshakeSuccess` handler from the authentication methods. We do this so the `OnHandshakeSuccess` handler can perform longer initialization methods without sending the auth success message to the client.
+
+We are doing this because immediately after the client receives the auth successful message it will start sending requests which may time out.
+
+We can do this because we know that the Go SSH library doesn't support chained authentication. (e.g. password + keyboard-interactive).
+
+**Remove:** When Go SSH supports multiple chained authentication methods.


### PR DESCRIPTION
This change moves the call to OnHandshakeSuccessful before sending the "auth success" message to the client.

This is required because we noticed that clients would immediately start sending requests (e.g. PTY requests) to the server while the container backend is still initializing. If the container initialization takes too long the PTY request would be considered failed by the client resulting in the error message "PTY allocation request failed on channel 0". By delaying sending the authentication response to the client we can make sure the container backend has ample time to start up the container.