### PR TITLE
Fixed incorrect request types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.14: Fixed incorrect request types
+
+In the previous version the SSH server would listen for several incorrect request types, for example PTY, signals, and subsystems. These are now fixed.
+
 ## 0.9.13: Fixed race condition on channel requests
 
 The previous version of this library would handle channel requests in parallel goroutines. This would sometimes lead to shell/exec/subsystem requests being processed before PTY requests. This release changes that and requests are now always processed in order.

--- a/server_impl.go
+++ b/server_impl.go
@@ -315,12 +315,12 @@ type requestType string
 
 const (
 	requestTypeEnv       requestType = "env"
-	requestTypePty       requestType = "pty"
+	requestTypePty       requestType = "pty-req"
 	requestTypeShell     requestType = "shell"
 	requestTypeExec      requestType = "exec"
-	requestTypeSubsystem requestType = "Subsystem"
+	requestTypeSubsystem requestType = "subsystem"
 	requestTypeWindow    requestType = "window-change"
-	requestTypeSignal    requestType = "Signal"
+	requestTypeSignal    requestType = "signal"
 )
 
 func (s *server) handleSessionChannel(channelID uint64, newChannel ssh.NewChannel, connection SSHConnectionHandler) {


### PR DESCRIPTION
In the previous version the SSH server would listen for several incorrect request types, for example PTY, signals, and subsystems. These are now fixed.